### PR TITLE
Add __name__ method into subscriber.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- __name__ method is added for preventing bug when you try to go in Components
+  tab into ZMI (/manage_components) or when you try to make a snapshot.
+  [bsuttor]
 
 
 1.2.1 (2014-05-23)

--- a/plone/multilingualbehavior/subscriber.py
+++ b/plone/multilingualbehavior/subscriber.py
@@ -91,4 +91,7 @@ class LanguageIndependentModifier(object):
         translations.remove(content_lang)
         return translations
 
+    def __name__(self):
+        return 'handler'
+
 handler = LanguageIndependentModifier()


### PR DESCRIPTION
Commit
---------
It is added for preventing bug when you try to go in Components  tab into ZMI (/manage_components) or when you try to make a snapshot.

Question
-----------
I make this pull request because of this bug :
plone/plone.app.multilingual#111

It seems GenericSetup utilities needs __name__ attribute:
https://github.com/zopefoundation/Products.GenericSetup/blob/master/Products/GenericSetup/utils.py#L63

But when I saw the code, I'didn't understand why you/we have a class instead of a def method for a subscriber ?
And why the subscriber is registred in componentregistry.xml and not in zcml ?