### PR TITLE
Made the __name__ method of the handler a property.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.2.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Made the ``__name__`` method of the handler a property.
+  Otherwise you get a very weird name with 'bound method' in it.
+  [maurits]
 
 
 1.2.2 (2019-12-24)
@@ -13,7 +15,7 @@ Changelog
 - Add uninstall step.
   [bsuttor]
 
-- __name__ method is added for preventing bug when you try to go in Components
+- ``__name__`` method is added for preventing bug when you try to go in Components
   tab into ZMI (/manage_components) or when you try to make a snapshot.
   [bsuttor]
 

--- a/plone/multilingualbehavior/subscriber.py
+++ b/plone/multilingualbehavior/subscriber.py
@@ -91,6 +91,7 @@ class LanguageIndependentModifier(object):
         translations.remove(content_lang)
         return translations
 
+    @property
     def __name__(self):
         return 'handler'
 


### PR DESCRIPTION
Otherwise you get a very weird name with 'bound method' in it:

```
  <subscriber
     for="plone.multilingualbehavior.interfaces.IDexterityTranslatable
           plone.dexterity.interfaces.IEditFinishedEvent"
     handler="plone.multilingualbehavior.subscriber.&lt;bound method
 LanguageIndependentModifier.multilingualbehavior.subscriber.LanguageIndependentModifier
 object at 0x112d5e290&gt;&gt;"/>
```

Or in a bin/instance debug session:

```
>>> from plone.multilingualbehavior import subscriber
>>> subscriber.LanguageIndependentModifier
<class 'plone.multilingualbehavior.subscriber.LanguageIndependentModifier'>
>>> subscriber.LanguageIndependentModifier.__name__
'LanguageIndependentModifier'
>>> subscriber.handler
<plone.multilingualbehavior.subscriber.LanguageIndependentModifier object at 0x1140d17d0>
>>> subscriber.handler.__name__
<bound method LanguageIndependentModifier.__name__ of <plone.multilingualbehavior.subscriber.LanguageIndependentModifier object at 0x1140d17d0>>
>>> subscriber.handler.__name__()
'handler'
```

Related to https://github.com/plone/plone.multilingualbehavior/pull/8